### PR TITLE
BASIC filtering of String fields via query params

### DIFF
--- a/server/single_server_test.go
+++ b/server/single_server_test.go
@@ -125,4 +125,10 @@ func (s *SingleServerSuite) Test_SingleServer(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(res.StatusCode, Equals, 200)
 	c.Assert(isJSONBody(res), Equals, true)
+
+	// Test filtering
+	res, err = getEndpoint("/db/foo?name=fiona")
+	c.Assert(err, IsNil)
+	c.Assert(res.StatusCode, Equals, 200)
+	c.Assert(isJSONBody(res), Equals, true)
 }


### PR DESCRIPTION
support to basic string field filtering. Note this does not look up the schema and throw validation if field is not String
